### PR TITLE
Fix ESLint extends configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-  extends: ['plugin:storybook/recommended'],
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: './tsconfig.json',
@@ -10,6 +9,7 @@ module.exports = {
     node: true
   },
   extends: [
+    'plugin:storybook/recommended',
     'next',
     'plugin:import/recommended',
     'plugin:import/typescript',


### PR DESCRIPTION
## Summary
- merge duplicate `extends` entries in `.eslintrc.js`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b1a44b9208330beba24bb0d060938